### PR TITLE
do not keep backslash in paths when building on windows for wasm

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.wasm32-unknown-unknown]
+runner = "wasm-bindgen-test-runner"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,9 +61,7 @@ jobs:
       - name: Install wasm-bindgen
         run: cargo install --force wasm-bindgen-cli
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test --target wasm32-unknown-unknown
 
   clippy_check:
     name: Clippy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,18 +100,9 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: rustfmt
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all -- --check
 
   deny:
     name: Deny
@@ -119,27 +110,13 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            profile: minimal
-            override: true
-      - name: Install cargo quickinstall
-        uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cargo-quickinstall
-      - name: Install cargo deny
-        uses: actions-rs/cargo@v1
-        with:
-          command: quickinstall
-          args: cargo-deny
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install tooling
+        run: |
+          cargo install cargo-quickinstall
+          cargo quickinstall cargo-deny
       - name: Run cargo deny
-        uses: actions-rs/cargo@v1
-        with:
-          command: deny
-          args: check
+        run: cargo deny check
 
   doc:
     name: Doc

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -116,10 +116,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --no-deps
+      - name: Run cargo doc
+        run: cargo doc --no-deps
         env:
           RUSTDOCFLAGS: -D warnings

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,9 @@ jobs:
     name: Test Suite
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -42,9 +42,9 @@ jobs:
     name: WASM Test Suite
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -68,9 +68,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - name: Run cargo fmt
         run: cargo fmt --all -- --check
@@ -100,7 +100,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - name: Install tooling
         run: |
@@ -114,7 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
       - name: Install wasm-bindgen
         run: |
           cargo install cargo-quickinstall
-          cargo quickinstall --force wasm-bindgen-cli
+          cargo quickinstall wasm-bindgen-cli
       - name: Run cargo test
         run: cargo test --target wasm32-unknown-unknown
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,13 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        toolchain: [stable, nightly]
         os: [windows-latest, ubuntu-latest, macos-latest]
-        exclude:
-          - os: macos-latest
-            toolchain: nightly
-          - os: windows-latest
-            toolchain: nightly
     runs-on: ${{ matrix.os }}
     name: Test Suite
     steps:
@@ -33,15 +27,39 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install Dependencies
         if: runner.os == 'linux'
         run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  wasm-test:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    name: WASM Test Suite
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-wasm-test-${{ hashFiles('**/Cargo.toml') }}
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          target: wasm32-unknown-unknown
+      - name: Install wasm-bindgen
+        run: cargo install --force wasm-bindgen-cli
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,9 +32,7 @@ jobs:
         if: runner.os == 'linux'
         run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
+        run: cargo test
 
   wasm-test:
     strategy:
@@ -81,20 +79,11 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          components: clippy
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install Dependencies
         run: sudo apt-get update; sudo apt-get install pkg-config libx11-dev libasound2-dev libudev-dev
       - name: Run clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings
 
   format:
     name: Format
@@ -126,12 +115,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,9 @@ jobs:
         with:
           target: wasm32-unknown-unknown
       - name: Install wasm-bindgen
-        run: cargo install --force wasm-bindgen-cli
+        run: |
+          cargo install cargo-quickinstall
+          cargo quickinstall --force wasm-bindgen-cli
       - name: Run cargo test
         run: cargo test --target wasm32-unknown-unknown
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ features = ["bevy_asset"]
 
 [build-dependencies]
 cargo-emit = "0.2.1"
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/assets/subdir/other_asset
+++ b/assets/subdir/other_asset
@@ -1,0 +1,1 @@
+in subdirectory

--- a/build.rs
+++ b/build.rs
@@ -67,16 +67,23 @@ fn main() {
         )
         .unwrap();
 
+        let building_for_wasm = std::env::var("CARGO_CFG_TARGET_ARCH") == Ok("wasm32".to_string());
+
         visit_dirs(&dir)
             .iter()
             .map(|path| (path, path.strip_prefix(&dir).unwrap()))
             .for_each(|(fullpath, path)| {
+                let mut path = path.to_string_lossy().to_string();
+                if building_for_wasm {
+                    // building for wasm. replace paths with forward slash in case we're building from windows
+                    path = path.replace("\\", "/");
+                }
                 cargo_emit::rerun_if_changed!(fullpath.to_string_lossy());
                 file.write_all(
                     format!(
                         r#"embedded.add_asset(std::path::Path::new({:?}), include_bytes!({:?}));
 "#,
-                        path.to_string_lossy(),
+                        path,
                         fullpath.to_string_lossy()
                     )
                     .as_ref(),

--- a/build.rs
+++ b/build.rs
@@ -59,7 +59,7 @@ fn main() {
         let out_dir = env::var_os("OUT_DIR").unwrap();
         let dest_path = Path::new(&out_dir).join("include_all_assets.rs");
 
-        let mut file = File::create(&dest_path).unwrap();
+        let mut file = File::create(dest_path).unwrap();
         file.write_all(
         "/// Generated function that will add all assets to the [`EmbeddedAssetIo`].
 #[allow(unused_variables, clippy::non_ascii_literal)] pub fn include_all_assets(embedded: &mut EmbeddedAssetIo){\n"
@@ -89,7 +89,7 @@ fn main() {
         let out_dir = env::var_os("OUT_DIR").unwrap();
         let dest_path = Path::new(&out_dir).join("include_all_assets.rs");
 
-        let mut file = File::create(&dest_path).unwrap();
+        let mut file = File::create(dest_path).unwrap();
         file.write_all(
             "/// Generated function that will add all assets to the [`EmbeddedAssetIo`].
     #[allow(unused_variables)] pub fn include_all_assets(embedded: &mut EmbeddedAssetIo){}"

--- a/build.rs
+++ b/build.rs
@@ -76,7 +76,7 @@ fn main() {
                 let mut path = path.to_string_lossy().to_string();
                 if building_for_wasm {
                     // building for wasm. replace paths with forward slash in case we're building from windows
-                    path = path.replace("\\", "/");
+                    path = path.replace('\\', "/");
                 }
                 cargo_emit::rerun_if_changed!(fullpath.to_string_lossy());
                 file.write_all(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,8 +138,8 @@ mod tests {
     #[test]
     fn load_path() {
         let mut embedded = EmbeddedAssetIo::new();
-        embedded.add_asset(&Path::new("asset.png"), &[1, 2, 3]);
-        embedded.add_asset(&Path::new("other_asset.png"), &[4, 5, 6]);
+        embedded.add_asset(Path::new("asset.png"), &[1, 2, 3]);
+        embedded.add_asset(Path::new("other_asset.png"), &[4, 5, 6]);
 
         assert!(embedded.load_path_sync(&Path::new("asset.png")).is_ok());
         assert_eq!(
@@ -159,8 +159,8 @@ mod tests {
     #[test]
     fn is_directory() {
         let mut embedded = EmbeddedAssetIo::new();
-        embedded.add_asset(&Path::new("asset.png"), &[]);
-        embedded.add_asset(&Path::new("directory/asset.png"), &[]);
+        embedded.add_asset(Path::new("asset.png"), &[]);
+        embedded.add_asset(Path::new("directory/asset.png"), &[]);
 
         assert!(!embedded
             .get_metadata(&Path::new("asset.png"))
@@ -184,9 +184,9 @@ mod tests {
     #[test]
     fn read_directory() {
         let mut embedded = EmbeddedAssetIo::new();
-        embedded.add_asset(&Path::new("asset.png"), &[]);
-        embedded.add_asset(&Path::new("directory/asset.png"), &[]);
-        embedded.add_asset(&Path::new("directory/asset2.png"), &[]);
+        embedded.add_asset(Path::new("asset.png"), &[]);
+        embedded.add_asset(Path::new("directory/asset.png"), &[]);
+        embedded.add_asset(Path::new("directory/asset2.png"), &[]);
 
         assert!(embedded.read_directory(&Path::new("asset.png")).is_err());
         assert!(embedded.read_directory(&Path::new("directory")).is_ok());

--- a/tests/preloaded.rs
+++ b/tests/preloaded.rs
@@ -1,8 +1,11 @@
 use std::path::Path;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_test::wasm_bindgen_test;
 
 use bevy_embedded_assets::EmbeddedAssetIo;
 
-#[test]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn check_preloaded_simple() {
     let embedded = EmbeddedAssetIo::preloaded();
 
@@ -15,7 +18,8 @@ fn check_preloaded_simple() {
     assert_eq!(String::from_utf8(raw_asset).unwrap(), "hello");
 }
 
-#[test]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn check_preloaded_special_chars() {
     let embedded = EmbeddedAssetIo::preloaded();
 
@@ -28,7 +32,8 @@ fn check_preloaded_special_chars() {
     assert_eq!(String::from_utf8(raw_asset).unwrap(), "with special chars");
 }
 
-#[test]
+#[cfg_attr(not(target_arch = "wasm32"), test)]
+#[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
 fn check_preloaded_subdir() {
     let embedded = EmbeddedAssetIo::preloaded();
 

--- a/tests/preloaded.rs
+++ b/tests/preloaded.rs
@@ -3,18 +3,27 @@ use std::path::Path;
 use bevy_embedded_assets::EmbeddedAssetIo;
 
 #[test]
-fn check_preloaded() {
+fn check_preloaded_simple() {
     let embedded = EmbeddedAssetIo::preloaded();
 
-    assert!(embedded.load_path_sync(&Path::new("example_asset")).is_ok());
-    let raw_asset = embedded
-        .load_path_sync(&Path::new("example_asset"))
-        .unwrap();
+    let path = "example_asset";
+
+    let loaded = embedded.load_path_sync(&Path::new(path));
+    assert!(loaded.is_ok());
+    let raw_asset = loaded.unwrap();
     assert!(String::from_utf8(raw_asset.clone()).is_ok());
     assert_eq!(String::from_utf8(raw_asset).unwrap(), "hello");
+}
 
-    assert!(embedded.load_path_sync(&Path::new("açèt")).is_ok());
-    let raw_asset = embedded.load_path_sync(&Path::new("açèt")).unwrap();
+#[test]
+fn check_preloaded_special_chars() {
+    let embedded = EmbeddedAssetIo::preloaded();
+
+    let path = "açèt";
+
+    let loaded = embedded.load_path_sync(&Path::new(path));
+    assert!(loaded.is_ok());
+    let raw_asset = loaded.unwrap();
     assert!(String::from_utf8(raw_asset.clone()).is_ok());
     assert_eq!(String::from_utf8(raw_asset).unwrap(), "with special chars");
 }

--- a/tests/preloaded.rs
+++ b/tests/preloaded.rs
@@ -27,3 +27,16 @@ fn check_preloaded_special_chars() {
     assert!(String::from_utf8(raw_asset.clone()).is_ok());
     assert_eq!(String::from_utf8(raw_asset).unwrap(), "with special chars");
 }
+
+#[test]
+fn check_preloaded_subdir() {
+    let embedded = EmbeddedAssetIo::preloaded();
+
+    let path = "subdir/other_asset";
+
+    let loaded = embedded.load_path_sync(&Path::new(path));
+    assert!(loaded.is_ok());
+    let raw_asset = loaded.unwrap();
+    assert!(String::from_utf8(raw_asset.clone()).is_ok());
+    assert_eq!(String::from_utf8(raw_asset).unwrap(), "in subdirectory");
+}


### PR DESCRIPTION
Fixes #7 

* run tests in wasm
* when building for wasm, change backslashes to slashes in the build script