### PR TITLE
Add support for AssetMode::Processed

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,14 @@ fn main() {
                     for ancestor in path.ancestors() {
                         if let Some(last) = ancestor.file_name() {
                             if last == "target" {
-                                return ancestor.parent().map(|p| p.join("assets"));
+                                return ancestor.parent().map(|parent| {
+                                    let imported_dir = parent.join("imported_assets");
+                                    return if imported_dir.exists() {
+                                        imported_dir.join("Default")
+                                    } else {
+                                        parent.join("assets")
+                                    };
+                                });
                             }
                         }
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,9 @@ impl Plugin for EmbeddedAssetPlugin {
                 }
                 app.register_asset_source(
                     AssetSourceId::Default,
-                    AssetSource::build().with_reader(|| Box::new(EmbeddedAssetReader::preloaded())),
+                    AssetSource::build()
+                        .with_reader(|| Box::new(EmbeddedAssetReader::preloaded()))
+                        .with_processed_reader(|| Box::new(EmbeddedAssetReader::preloaded())),
                 );
             }
             #[cfg(feature = "default-source")]


### PR DESCRIPTION
I wanted to use this plugin with `AssetMode::Processed` with `PluginMode::ReplaceDefault` so I made these minimal changes to get it to work.

The default asset folder is selected based on whether an `imported_assets` folder exists or not. Ideally it would be selected whether `AssetMode::Processed` is set but I don't think can be known at compile time.