### PR TITLE
fix: always use forward slash when cross compiling from windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -75,15 +75,16 @@ fn include_all_assets(mut registry: impl EmbeddedRegistry){\n"
         )
         .unwrap();
 
-        let building_for_wasm = std::env::var("CARGO_CFG_TARGET_ARCH") == Ok("wasm32".to_string());
+        let building_for_not_windows =
+            std::env::var("CARGO_CFG_TARGET_OS").is_ok_and(|v| v != "windows");
 
         visit_dirs(&dir)
             .iter()
             .map(|path| (path, path.strip_prefix(&dir).unwrap()))
             .for_each(|(fullpath, path)| {
                 let mut path = path.to_string_lossy().to_string();
-                if building_for_wasm {
-                    // building for wasm. replace paths with forward slash in case we're building from windows
+                if building_for_not_windows {
+                    // replace paths with forward slash in case we're building from windows
                     path = path.replace(std::path::MAIN_SEPARATOR, "/");
                 }
                 cargo_emit::rerun_if_changed!(fullpath.to_string_lossy());


### PR DESCRIPTION
I ran into an issue where embedded assets wouldn't work when building to Android from Windows because they had the wrong path separators. (I know this plugin isn't generally useful for Android, but I had to use this as bevy 0.15 wasn't able to read directories on Android).

I haven't tested it when cross compiling to other platforms, but always changing to a forward slash outside of Windows seems sensible.
