### PR TITLE
chore: release v0.13.0-rc.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_embedded_assets"
-version = "0.13.0-rc.2"
+version = "0.13.0"
 authors = ["François Mockers <mockersf@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_embedded_assets"
-version = "0.13.0-rc.1"
+version = "0.13.0-rc.2"
 authors = ["François Mockers <mockersf@gmail.com>"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ fn main() {
 |Bevy|bevy_embedded_assets|
 |---|---|
 |main|main|
+|0.16|0.13|
 |0.15|0.12|
 |0.14|0.11|
 |0.13|0.10|


### PR DESCRIPTION



## 🤖 New release

* `bevy_embedded_assets`: 0.13.0-rc.1 -> 0.13.0-rc.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).