### PR TITLE
feat!: Bevy 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ default = ["default-source"]
 default-source = ["futures-io", "futures-lite", "log"]
 
 [dependencies]
-bevy_asset = { version = "0.17", default-features = false }
-bevy_ecs = { version = "0.17", default-features = false }
-bevy_app = { version = "0.17", default-features = false }
+bevy_asset = { version = "0.18", default-features = false }
+bevy_ecs = { version = "0.18", default-features = false }
+bevy_app = { version = "0.18", default-features = false }
 
 futures-io = { version = "0.3", optional = true }
 futures-lite = { version = "2.6", optional = true }
@@ -28,7 +28,7 @@ log = { version = "0.4", optional = true }
 thiserror = "2.0"
 
 [dev-dependencies]
-bevy = { version = "0.17", default-features = false, features = ["bevy_asset"] }
+bevy = { version = "0.18", default-features = false, features = ["bevy_asset"] }
 
 [build-dependencies]
 cargo-emit = "0.2.1"

--- a/src/asset_reader.rs
+++ b/src/asset_reader.rs
@@ -276,20 +276,20 @@ mod tests {
         let mut embedded = EmbeddedAssetReader::new();
         embedded.add_asset(Path::new("asset.png"), &[1, 2, 3]);
         embedded.add_asset(Path::new("other_asset.png"), &[4, 5, 6]);
-        assert!(embedded.load_path_sync(&Path::new("asset.png")).is_ok());
+        assert!(embedded.load_path_sync(Path::new("asset.png")).is_ok());
         assert_eq!(
-            embedded.load_path_sync(&Path::new("asset.png")).unwrap().0,
+            embedded.load_path_sync(Path::new("asset.png")).unwrap().0,
             [1, 2, 3]
         );
         assert_eq!(
             embedded
-                .load_path_sync(&Path::new("other_asset.png"))
+                .load_path_sync(Path::new("other_asset.png"))
                 .unwrap()
                 .0,
             [4, 5, 6]
         );
-        assert!(embedded.load_path_sync(&Path::new("asset")).is_err());
-        assert!(embedded.load_path_sync(&Path::new("other")).is_err());
+        assert!(embedded.load_path_sync(Path::new("asset")).is_err());
+        assert!(embedded.load_path_sync(Path::new("other")).is_err());
     }
 
     #[cfg_attr(not(target_arch = "wasm32"), test)]
@@ -298,11 +298,11 @@ mod tests {
         let mut embedded = EmbeddedAssetReader::new();
         embedded.add_asset(Path::new("asset.png"), &[]);
         embedded.add_asset(Path::new("directory/asset.png"), &[]);
-        assert!(!embedded.is_directory_sync(&Path::new("asset.png")));
-        assert!(!embedded.is_directory_sync(&Path::new("asset")));
-        assert!(embedded.is_directory_sync(&Path::new("directory")));
-        assert!(embedded.is_directory_sync(&Path::new("directory/")));
-        assert!(!embedded.is_directory_sync(&Path::new("directory/asset")));
+        assert!(!embedded.is_directory_sync(Path::new("asset.png")));
+        assert!(!embedded.is_directory_sync(Path::new("asset")));
+        assert!(embedded.is_directory_sync(Path::new("directory")));
+        assert!(embedded.is_directory_sync(Path::new("directory/")));
+        assert!(!embedded.is_directory_sync(Path::new("directory/asset")));
     }
 
     #[cfg_attr(not(target_arch = "wasm32"), test)]
@@ -314,16 +314,12 @@ mod tests {
         embedded.add_asset(Path::new("directory/asset2.png"), &[]);
         assert!(
             embedded
-                .read_directory_sync(&Path::new("asset.png"))
+                .read_directory_sync(Path::new("asset.png"))
                 .is_err()
         );
-        assert!(
-            embedded
-                .read_directory_sync(&Path::new("directory"))
-                .is_ok()
-        );
+        assert!(embedded.read_directory_sync(Path::new("directory")).is_ok());
         let mut list = embedded
-            .read_directory_sync(&Path::new("directory"))
+            .read_directory_sync(Path::new("directory"))
             .unwrap()
             .0
             .iter()
@@ -343,7 +339,7 @@ mod tests {
 
         let path = "example_asset.test";
 
-        let loaded = embedded.load_path_sync(&Path::new(path));
+        let loaded = embedded.load_path_sync(Path::new(path));
         assert!(loaded.is_ok());
         let raw_asset = loaded.unwrap();
         assert!(String::from_utf8(raw_asset.0.to_vec()).is_ok());
@@ -357,7 +353,7 @@ mod tests {
 
         let path = "açèt.test";
 
-        let loaded = embedded.load_path_sync(&Path::new(path));
+        let loaded = embedded.load_path_sync(Path::new(path));
         assert!(loaded.is_ok());
         let raw_asset = loaded.unwrap();
         assert!(String::from_utf8(raw_asset.0.to_vec()).is_ok());
@@ -374,7 +370,7 @@ mod tests {
 
         let path = "subdir/other_asset.test";
 
-        let loaded = embedded.load_path_sync(&Path::new(path));
+        let loaded = embedded.load_path_sync(Path::new(path));
         assert!(loaded.is_ok());
         let raw_asset = loaded.unwrap();
         assert!(String::from_utf8(raw_asset.0.to_vec()).is_ok());

--- a/src/asset_reader.rs
+++ b/src/asset_reader.rs
@@ -7,7 +7,8 @@ use std::{
 };
 
 use bevy_asset::io::{
-    AssetReader, AssetReaderError, AsyncSeekForward, ErasedAssetReader, PathStream, Reader,
+    AssetReader, AssetReaderError, ErasedAssetReader, PathStream, Reader, ReaderNotSeekableError,
+    SeekableReader,
 };
 use futures_io::{AsyncRead, AsyncSeek};
 use futures_lite::Stream;
@@ -159,6 +160,10 @@ impl Reader for DataReader {
         let future = futures_lite::AsyncReadExt::read_to_end(self, buf);
         bevy_asset::io::StackFuture::from(future)
     }
+
+    fn seekable(&mut self) -> Result<&mut dyn SeekableReader, ReaderNotSeekableError> {
+        Ok(self)
+    }
 }
 
 impl AsyncRead for DataReader {
@@ -184,21 +189,9 @@ impl AsyncSeek for DataReader {
     }
 }
 
-impl AsyncSeekForward for DataReader {
-    fn poll_seek_forward(
-        self: Pin<&mut Self>,
-        _: &mut std::task::Context<'_>,
-        _offset: u64,
-    ) -> Poll<futures_io::Result<u64>> {
-        Poll::Ready(Err(futures_io::Error::other(
-            EmbeddedDataReaderError::SeekNotSupported,
-        )))
-    }
-}
-
 #[derive(Error, Debug)]
 enum EmbeddedDataReaderError {
-    #[error("Seek is not supported when embeded")]
+    #[error("Seek is not supported when embedded")]
     SeekNotSupported,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use bevy_ecs::resource::Resource;
 use {
     bevy_asset::{
         AssetApp,
-        io::{AssetSource, AssetSourceId},
+        io::{AssetSource, AssetSourceBuilder, AssetSourceId},
     },
     log::error,
 };
@@ -141,8 +141,7 @@ impl Plugin for EmbeddedAssetPlugin {
                 }
                 app.register_asset_source(
                     AssetSourceId::Default,
-                    AssetSource::build()
-                        .with_reader(|| Box::new(EmbeddedAssetReader::preloaded()))
+                    AssetSourceBuilder::new(|| Box::new(EmbeddedAssetReader::preloaded()))
                         .with_processed_reader(|| Box::new(EmbeddedAssetReader::preloaded())),
                 );
             }
@@ -156,7 +155,7 @@ impl Plugin for EmbeddedAssetPlugin {
                 let path = path.clone();
                 app.register_asset_source(
                     AssetSourceId::Default,
-                    AssetSource::build().with_reader(move || {
+                    AssetSourceBuilder::new(move || {
                         Box::new(EmbeddedAssetReader::preloaded_with_default(
                             AssetSource::get_default_reader(path.clone()),
                         ))

--- a/tests/as_default.rs
+++ b/tests/as_default.rs
@@ -14,7 +14,7 @@ pub struct TestAsset {
     pub value: String,
 }
 
-#[derive(Default)]
+#[derive(Default, TypePath)]
 pub struct TestAssetLoader;
 
 #[derive(Debug, Error)]

--- a/tests/as_default_with_fallback.rs
+++ b/tests/as_default_with_fallback.rs
@@ -14,7 +14,7 @@ pub struct TestAsset {
     pub value: String,
 }
 
-#[derive(Default)]
+#[derive(Default, TypePath)]
 pub struct TestAssetLoader;
 
 #[derive(Debug, Error)]

--- a/tests/embedded.rs
+++ b/tests/embedded.rs
@@ -12,7 +12,7 @@ pub struct TestAsset {
     pub value: String,
 }
 
-#[derive(Default)]
+#[derive(Default, TypePath)]
 pub struct TestAssetLoader;
 
 #[derive(Debug, Error)]


### PR DESCRIPTION
Closes #31 

- Upgraded Bevy version requirement to 0.18.
- Migrated all code based on the 0.17 to 0.18 migration guide.
- Fixed a few typos and lints.