### PR TITLE
Bump bevy to 0.19.*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ default = ["default-source"]
 default-source = ["futures-io", "futures-lite", "log"]
 
 [dependencies]
-bevy_asset = { version = "0.18", default-features = false }
-bevy_ecs = { version = "0.18", default-features = false }
-bevy_app = { version = "0.18", default-features = false }
+bevy_asset = { version = "0.19", default-features = false }
+bevy_ecs = { version = "0.19", default-features = false }
+bevy_app = { version = "0.19", default-features = false }
 
 futures-io = { version = "0.3", optional = true }
 futures-lite = { version = "2.6", optional = true }
@@ -28,7 +28,7 @@ log = { version = "0.4", optional = true }
 thiserror = "2.0"
 
 [dev-dependencies]
-bevy = { version = "0.18", default-features = false, features = ["bevy_asset"] }
+bevy = { version = "0.19", default-features = false, features = ["bevy_asset"] }
 
 [build-dependencies]
 cargo-emit = "0.2.1"


### PR DESCRIPTION
Bump all bevy dependencies to 0.19. 

Tested on 2 of my projects that use this crate and they worked without any errors.